### PR TITLE
Revert "feat(dev-tools): extends @semantic-release/git to add package-lock.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,19 +60,6 @@
   "release": {
     "extends": [
       "@pplancq/semantic-release-config"
-    ],
-    "plugins": [
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json",
-            "../../package-lock.json",
-            "CHANGELOG.md"
-          ],
-          "message": "chore(release): ${nextRelease.name} [skip ci]\n\n${nextRelease.notes}"
-        }
-      ]
     ]
   },
   "multi-release": {


### PR DESCRIPTION
Reverts pplancq/dev-tools#108

overloading the semantic release configuration seems to work, but it disables all the other plugins, which complicates the release.