### PR TITLE
chore(semantic-release-config): add package-lock when execute npm version

### DIFF
--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/semantic-release-config"
   },
+  "scripts": {
+    "version": "git add ../../package-lock.json"
+  },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature

**Associated Issue :**

#103

**Context :**

add package-lock when execute npm version only on semantic-release-config for test

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

