### PR TITLE
chore(dev-tools): add package-lock when execute npm postversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23000,7 +23000,7 @@
     },
     "packages/react-template": {
       "name": "@pplancq/react-template",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^3.3.2",
@@ -23050,7 +23050,7 @@
     },
     "packages/semantic-release-config": {
       "name": "@pplancq/semantic-release-config",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@semantic-release/changelog": "^6.0.3",

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/babel-config"
   },
+  "scripts": {
+    "postversion": "git add ../../package-lock.json"
+  },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/commitlint-config"
   },
+  "scripts": {
+    "postversion": "git add ../../package-lock.json"
+  },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -85,7 +85,7 @@ const main = async () => {
   const repoPackageJson = JSON.parse(readFileSync(resolve(repoDir, 'package.json'), { encoding: 'utf-8' }));
   repoPackageJson.name = projectName;
   repoPackageJson.description = projectName;
-  const { _prepare, ...scripts } = repoPackageJson.scripts;
+  const { _prepare, postversion, ...scripts } = repoPackageJson.scripts;
   repoPackageJson.scripts = { ...scripts, prepare: _prepare };
 
   delete repoPackageJson.author;

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/create-react-app"
   },
+  "scripts": {
+    "postversion": "git add ../../package-lock.json"
+  },
   "bin": "./index.js",
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/eslint-config"
   },
+  "scripts": {
+    "postversion": "git add ../../package-lock.json"
+  },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },

--- a/packages/postcss-config/package.json
+++ b/packages/postcss-config/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/postcss-config"
   },
+  "scripts": {
+    "postversion": "git add ../../package-lock.json"
+  },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/prettier-config"
   },
+  "scripts": {
+    "postversion": "git add ../../package-lock.json"
+  },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },

--- a/packages/react-template/package.json
+++ b/packages/react-template/package.json
@@ -23,6 +23,7 @@
     "package:check": "npm exec --yes package-lock-utd@1.1.3",
     "remove:demo": "./scripts/removeDemo.js",
     "migrate:vite": "./scripts/migrateToVite.js",
+    "postversion": "git add ../../package-lock.json",
     "_prepare": "husky"
   },
   "bugs": {

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/semantic-release-config"
   },
   "scripts": {
-    "version": "git add ../../package-lock.json"
+    "postversion": "git add ../../package-lock.json"
   },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/stylelint-config"
   },
+  "scripts": {
+    "postversion": "git add ../../package-lock.json"
+  },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/pplancq/dev-tools",
     "directory": "packages/webpack-config"
   },
+  "scripts": {
+    "postversion": "git add ../../package-lock.json"
+  },
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature

**Associated Issue :**

fix #103 

**Context :**

add package-lock when execute npm postversion

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)
