### PR TITLE
Fix: Remove outdated `useEslintrc: true` option in Vite migration script

### DIFF
--- a/packages/react-template/scripts/migrateToVite.js
+++ b/packages/react-template/scripts/migrateToVite.js
@@ -56,7 +56,6 @@ export default defineConfig(({ mode }) => {
       viteTsconfigPaths(),
       svgr(),
       eslintPlugin({
-        useEslintrc: true,
         emitErrorAsWarning: true,
         cache: false
       }),


### PR DESCRIPTION
**Type of Pull Request :**

- [x] Bug fix

**Associated Issue :**

[Issue #849](https://github.com/pplancq/dev-tools/issues/849)

**Context :**

The migration script for Vite mistakenly included the `useEslintrc: true` option in the ESLint plugin configuration. However, this option is no longer necessary as ESLint v9 does not use RC configuration files anymore. This caused an error when starting the development server.

**Proposed Changes :**

- Removed the `useEslintrc: true` option from the migration script for Vite.

**Checklist :**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [ ] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

Testing this fix was not conducted, as it is complex to simulate the specific scenario reliably.