### PR TITLE
Deprecate enableJest option and add warning message

### DIFF
--- a/packages/eslint-config/main.js
+++ b/packages/eslint-config/main.js
@@ -17,7 +17,7 @@ const { playwrightRules } = require('./rules/playwright');
  * @param {string[]} [options.unitE2eFiles=['tests/**\/*.{test,spec}.{js,jsx,ts,tsx}']]
  * @param {boolean} [options.enableReact=false]
  * @param {boolean} [options.enableVitest=false]
- * @param {boolean} [options.enableJest=false]
+ * @param {boolean} [options.enableJest=false] - Deprecated This option is deprecated and will be removed in the next major release. Please migrate to an alternative (e.g., Vitest).
  * @param {boolean} [options.enablePlaywright=false]
  * @param {'off' | 'on' | 'disableStyleOnly'} [options.enablePrettier='on']
  * @param {Array<import('eslint').Linter.Config>} [options.extendConfig=[]]
@@ -35,6 +35,12 @@ const defineConfig = ({
   enablePrettier = 'off',
   extendConfig = [],
 } = {}) => {
+  if (enableJest) {
+    console.warn(
+      '[DEPRECATED] The "enableJest" option is deprecated and will be removed in the next major release. Please migrate to an alternative (e.g., Vitest).',
+    );
+  }
+
   typescriptRules.files = tsFiles;
   reactTypescriptRules.files = tsFiles;
   reactTestRules.files = unitTestFiles;


### PR DESCRIPTION
**Type of Pull Request :**

- [ ] Bug fix  
- [ ] New feature  
- [ ] Documentation  
- [x] Other (specify): Deprecation

**Associated Issue :**

Closes #954

**Context :**

Cette Pull Request vise à déprécier l’option `enableJest` dans la configuration ESLint. L’objectif est d’informer les utilisateurs que cette option sera supprimée lors de la prochaine version majeure, et de les encourager à migrer vers une alternative comme Vitest. Cela permet d’anticiper la transition et d’éviter toute rupture future.

**Proposed Changes :**

- Ajout d’une mention `Deprecated` dans la JSDoc de l’option `enableJest`.
- Ajout d’un `console.warn` à l’exécution si `enableJest` est utilisé, précisant la dépréciation et la future suppression.
- Aucun changement de comportement pour l’instant, l’option reste fonctionnelle.

**Checklist :**

- [x] I have verified that my changes work as expected  
- [x] I have updated the documentation if necessary  
- [x] I have thought to rebase my branch  
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)
