### PR TITLE
Prevent app crash when launching ANDI accessibility tool

### DIFF
--- a/packages/react-template/src/__tests__/bootstraps.test.tsx
+++ b/packages/react-template/src/__tests__/bootstraps.test.tsx
@@ -1,0 +1,66 @@
+import { App } from '@Front/components/App';
+import { waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import bootstrap from '../bootstrap';
+
+vi.mock('@Front/components/App', () => ({
+  App: () => <div data-testid="app-mock">AppMock</div>,
+}));
+
+vi.mock('react-dom/client', () => ({
+  createRoot: vi.fn(),
+}));
+
+describe('bootstrap', () => {
+  let container: HTMLElement;
+  const render = vi.fn();
+  const unmount = vi.fn();
+  (createRoot as Mock).mockImplementation(() => ({
+    render,
+    unmount,
+  }));
+
+  customElements.define('bootstrap-html-element', bootstrap);
+
+  beforeEach(() => {
+    container = document.createElement('bootstrap-html-element');
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('should mount the React component in the custom element', () => {
+    document.body.appendChild(container);
+
+    expect(createRoot as Mock).toHaveBeenCalledWith(expect.anything());
+    expect(render).toBeCalledWith(
+      <StrictMode>
+        <App basename="" />
+      </StrictMode>,
+    );
+    expect(unmount).not.toHaveBeenCalled();
+  });
+
+  it('should unmount the React component when removed from the DOM', async () => {
+    document.body.appendChild(container);
+
+    expect(unmount).not.toHaveBeenCalled();
+
+    container.remove();
+
+    await waitFor(() => {
+      expect(unmount).toHaveBeenCalledWith();
+    });
+  });
+
+  it('should not unmount when element is removed and re-added to the DOM', async () => {
+    document.body.appendChild(container);
+    container.remove();
+    document.body.appendChild(container);
+
+    expect(unmount).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-template/src/bootstrap.tsx
+++ b/packages/react-template/src/bootstrap.tsx
@@ -6,6 +6,8 @@ import { createRoot, type Root } from 'react-dom/client';
 export default class Bootstrap extends HTMLElement {
   private readonly root: Root;
 
+  private isMounted = false;
+
   constructor() {
     super();
 
@@ -13,6 +15,7 @@ export default class Bootstrap extends HTMLElement {
   }
 
   connectedCallback() {
+    this.isMounted = true;
     this.root.render(
       <StrictMode>
         <App basename={this.getAttribute('basename') ?? ''} />
@@ -21,6 +24,12 @@ export default class Bootstrap extends HTMLElement {
   }
 
   disconnectedCallback() {
-    queueMicrotask(() => this.root.unmount());
+    this.isMounted = false;
+
+    queueMicrotask(() => {
+      if (!this.isMounted) {
+        this.root.unmount();
+      }
+    });
   }
 }


### PR DESCRIPTION
**Type of Pull Request:**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #1084

**Context:**
Launching the ANDI accessibility tool caused the React starter app to unload, making accessibility checks impossible. This bug blocked developers from verifying accessibility compliance using ANDI, which is critical for usability and legal requirements.

**Proposed Changes:**
- Added a new test suite for the custom bootstrap element to verify correct mounting and unmounting behavior.
- Refactored the bootstrap element to track its mounted state and prevent unnecessary unmounts when the element is removed and re-added to the DOM.
- Ensured the app remains loaded and accessible when ANDI is activated, allowing proper accessibility checks.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
