### PR TITLE
Add Vitest unit testing to create-react-app for code quality assurance

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
         run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose --color
 
   lint:
-    name: Lint code
+    name: Lint
     needs:
       - install
     runs-on: ubuntu-latest
@@ -64,7 +64,7 @@ jobs:
         run: npm run lint
 
   test:
-    name: Lint code
+    name: Test
     needs:
       - install
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,8 +63,23 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+  test:
+    name: Lint code
+    needs:
+      - install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Setup Node
+        uses: pplancq/actions/setup-node@main
+
+      - name: Run test
+        run: npm run test
+
   build:
-    name: Build template
+    name: Build
     needs:
       - install
     runs-on: ubuntu-latest
@@ -76,4 +91,7 @@ jobs:
         uses: pplancq/actions/setup-node@main
 
       - name: Run build
+        run: npm run build
+
+      - name: Run build template
         run: npm run build -w @pplancq/react-template

--- a/package-lock.json
+++ b/package-lock.json
@@ -21558,8 +21558,12 @@
       },
       "devDependencies": {
         "@rslib/core": "^0.12.2",
+        "@vitest/coverage-v8": "^3.2.4",
         "tsc-files": "^1.1.4",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^3.2.4",
+        "vitest-sonar-reporter": "^2.0.4"
       },
       "engines": {
         "node": ">=20.12.2"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "scripts": {
     "build": "npm run build -w @pplancq/create-react-app",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "node scripts/lint.js",
     "lint:eslint": "eslint \"**/*.{js,mjs}\" --ignore-pattern packages/react-template && npm run lint:eslint -w @pplancq/react-template",
     "lint:eslint:fix": "eslint \"**/*.{js,mjs}\" --fix --ignore-pattern packages/react-template && npm run lint:eslint:fix -w @pplancq/react-template",

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -19,7 +19,9 @@
   "main": "index.js",
   "scripts": {
     "start": "rslib build --watch",
-    "build": "rslib build"
+    "build": "rslib build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "create",
@@ -44,7 +46,11 @@
   },
   "devDependencies": {
     "@rslib/core": "^0.12.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "tsc-files": "^1.1.4",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.4",
+    "vitest-sonar-reporter": "^2.0.4"
   }
 }

--- a/packages/create-react-app/vitest.config.ts
+++ b/packages/create-react-app/vitest.config.ts
@@ -1,0 +1,38 @@
+import { loadEnv } from 'vite';
+import viteTsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [viteTsconfigPaths()],
+    test: {
+      setupFiles: 'vitest.setup.ts',
+      clearMocks: true,
+      reporters: ['default', 'junit', 'vitest-sonar-reporter'],
+      outputFile: {
+        'vitest-sonar-reporter': 'sonar-report.xml',
+        junit: 'junit-report.xml',
+      },
+      include: ['tests/**/*.{test,spec}.[jt]s?(x)'],
+      poolOptions: {
+        forks: {
+          minForks: env.CI ? 1 : undefined,
+          maxForks: env.CI ? 2 : undefined,
+        },
+      },
+      coverage: {
+        enabled: env.CI === 'true',
+        reporter: ['lcovonly', 'html', 'text', 'text-summary'],
+        provider: 'v8',
+        lines: 80,
+        functions: 75,
+        branches: 80,
+        statements: 80,
+        include: ['src/**/*.[jt]s?(x)'],
+        exclude: ['src/**/*.d.[jt]s?(x)', 'src/**/*.types.[jt]s?(x)', 'src/**/index.[jt]s?(x)'],
+      },
+    },
+  };
+});

--- a/packages/react-template/vitest.config.mts
+++ b/packages/react-template/vitest.config.mts
@@ -38,7 +38,7 @@ export default defineConfig(({ mode }) => {
       },
       coverage: {
         enabled: env.CI === 'true',
-        reporter: ['lcov', 'json', 'html', 'text', 'cobertura'],
+        reporter: ['lcovonly', 'html', 'text', 'text-summary'],
         provider: 'v8',
         lines: 80,
         functions: 75,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,39 @@
+import { loadEnv } from 'vite';
+// eslint-disable-next-line import/no-unresolved
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    test: {
+      projects: ['packages/*/vitest.config.{js,mjs,cjs,ts,mts,cts}'],
+      reporters: ['default', 'junit', 'vitest-sonar-reporter'],
+      outputFile: {
+        'vitest-sonar-reporter': 'sonar-report.xml',
+        junit: 'junit-report.xml',
+      },
+      poolOptions: {
+        forks: {
+          minForks: env.CI ? 1 : undefined,
+          maxForks: env.CI ? 2 : undefined,
+        },
+      },
+      coverage: {
+        enabled: env.CI === 'true',
+        reporter: ['lcovonly', 'html', 'text', 'text-summary'],
+        provider: 'v8',
+        lines: 80,
+        functions: 75,
+        branches: 80,
+        statements: 80,
+        include: ['packages/*/src/**/*.[jt]s?(x)'],
+        exclude: [
+          'packages/*/src/**/*.d.[jt]s?(x)',
+          'packages/*/src/**/*.types.[jt]s?(x)',
+          'packages/*/src/**/index.[jt]s?(x)',
+        ],
+      },
+    },
+  };
+});


### PR DESCRIPTION
**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #1088

**Context:**
The `create-react-app` package lacked integrated unit tests, making it difficult to guarantee code quality and reliability. This PR introduces Vitest as a unit testing framework to ensure future changes are validated and regressions are prevented.

**Proposed Changes:**
- Added Vitest and related dependencies to the monorepo and `create-react-app` package.
- Created Vitest configuration files for root and package scopes.
- Updated CI workflow to run tests and generate coverage reports.
- Added test scripts to package.json files.
- Improved coverage reporting and test output formats.
- Refactored build workflow for clarity and maintainability.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None