### PR TITLE
Replace chalk with picocolors for CLI output in create-react-app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21550,7 +21550,6 @@
       "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.6.0",
         "commander": "^14.0.0"
       },
       "bin": {
@@ -21559,6 +21558,7 @@
       "devDependencies": {
         "@rslib/core": "^0.12.2",
         "@vitest/coverage-v8": "^3.2.4",
+        "picocolors": "^1.1.1",
         "tsc-files": "^1.1.4",
         "typescript": "^5.9.2",
         "vite-tsconfig-paths": "^5.1.4",
@@ -21567,18 +21567,6 @@
       },
       "engines": {
         "node": ">=20.12.2"
-      }
-    },
-    "packages/create-react-app/node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "packages/eslint-config": {

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -35,7 +35,6 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "chalk": "^5.6.0",
     "commander": "^14.0.0"
   },
   "engines": {
@@ -47,6 +46,7 @@
   "devDependencies": {
     "@rslib/core": "^0.12.2",
     "@vitest/coverage-v8": "^3.2.4",
+    "picocolors": "^1.1.1",
     "tsc-files": "^1.1.4",
     "typescript": "^5.9.2",
     "vite-tsconfig-paths": "^5.1.4",

--- a/packages/create-react-app/src/main.ts
+++ b/packages/create-react-app/src/main.ts
@@ -2,6 +2,8 @@ import { execSync, type ExecSyncOptions } from 'child_process';
 import { Command } from 'commander';
 import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import pc from 'picocolors';
 
 const NPM = 'npm';
 const YARN = 'yarn';
@@ -28,8 +30,6 @@ const getPackageManager = () => {
 };
 
 export const main = async () => {
-  const chalk = await import('chalk').then(m => m.default);
-
   let projectName = '';
   const packageJson = JSON.parse(readFileSync(resolve(__dirname, './package.json'), { encoding: 'utf-8' }));
 
@@ -37,7 +37,7 @@ export const main = async () => {
   cli
     .version(packageJson.version)
     .argument('<project-name>')
-    .usage(chalk.green('<project-name>'))
+    .usage(pc.green('<project-name>'))
     .action(name => {
       projectName = name;
     })
@@ -62,14 +62,14 @@ export const main = async () => {
   const templateDir = resolve(repoDir, `./node_modules/${reactTemplate}`);
 
   if (existsSync(repoDir)) {
-    console.error(`\nThe directory ${chalk.green(projectName)} is already exist.`);
+    console.error(`\nThe directory ${pc.green(projectName)} is already exist.`);
     console.error('Either try using a new directory name, or remove the files listed above.');
     process.exit(-1);
   }
 
-  console.info(`\nCreating a new App React in ${chalk.green(repoDir)}.`);
+  console.info(`\nCreating a new App React in ${pc.green(repoDir)}.`);
 
-  console.info(`\nInstall react template from ${chalk.green(reactTemplate)}`);
+  console.info(`\nInstall react template from ${pc.green(reactTemplate)}`);
   mkdirSync(repoDir);
   runCommand(`cd ${repoDir} && npm init -y`, { stdio: 'ignore' });
   if (packageManager === YARN) {
@@ -129,10 +129,10 @@ export const main = async () => {
     stdio: 'ignore',
   });
 
-  console.info(`\n${chalk.yellow('Success \\o/')}  Created ${chalk.green(projectName)} at ${chalk.green(repoDir)}`);
+  console.info(`\n${pc.yellow('Success \\o/')}  Created ${pc.green(projectName)} at ${pc.green(repoDir)}`);
   console.info('Inside that directory, you can run several commands:');
   const logCommand = (command: string) => {
-    console.info(`\n  ${chalk.cyan(command)}`);
+    console.info(`\n  ${pc.cyan(command)}`);
   };
   logCommand(`${packageManager} start`);
   console.info('    Starts the development server.');
@@ -143,7 +143,7 @@ export const main = async () => {
   logCommand(`${packageManager} run remove:demo`);
   console.info('    Remove the demo application.');
   console.info('\nWe suggest that you begin by typing:');
-  console.info(`\n  ${chalk.cyan('cd')} ${projectName}`);
+  console.info(`\n  ${pc.cyan('cd')} ${projectName}`);
   logCommand(`${packageManager} start`);
   console.info('\nHappy hacking!');
 };

--- a/packages/create-react-app/vitest.setup.ts
+++ b/packages/create-react-app/vitest.setup.ts
@@ -1,0 +1,1 @@
+process.env.NO_COLOR = 'true';


### PR DESCRIPTION
**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #1163

**Context:**
The current CLI output in create-react-app uses chalk for coloring, which adds extra dependencies and increases package size. Migrating to picocolors provides a lighter, dependency-free alternative, improving install size and performance while maintaining colored output for usability.

**Proposed Changes:**
- Removed chalk from dependencies and code usage in create-react-app.
- Added picocolors as a replacement for CLI color output.
- Updated all CLI color calls to use picocolors (green, yellow, cyan, etc.).
- Updated package.json and package-lock.json accordingly.
- Added a vitest.setup.ts file to disable color in test output for consistency.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
