### PR TITLE
Refactor runCommand to use execFile for improved security

### DIFF
--- a/packages/create-react-app/eslint.config.js
+++ b/packages/create-react-app/eslint.config.js
@@ -5,13 +5,6 @@ export default defineConfig({
   enableVitest: true,
   extendConfig: [
     {
-      files: ['**/*.config.{js,cjs,mjs,ts,cts,mts}'],
-      rules: {
-        'import/no-default-export': 'off',
-        'import/no-extraneous-dependencies': 'off',
-      },
-    },
-    {
       ignores: ['dist'],
     },
     {
@@ -19,6 +12,23 @@ export default defineConfig({
       rules: {
         'import/extensions': 'off',
         'import/no-unresolved': 'off',
+      },
+    },
+    {
+      rules: {
+        'import/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: true,
+          },
+        ],
+      },
+    },
+    {
+      files: ['**/*.config.{js,cjs,mjs,ts,cts,mts}'],
+      rules: {
+        'import/no-default-export': 'off',
+        'import/no-extraneous-dependencies': 'off',
       },
     },
   ],

--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
-import { main } from './dist/main';
+import { main } from './dist/main.js';
 
 main();

--- a/packages/create-react-app/src/helpers/endProcess.ts
+++ b/packages/create-react-app/src/helpers/endProcess.ts
@@ -1,0 +1,3 @@
+export const endProcess = (error = false) => {
+  process.exit(error ? 1 : 0);
+};

--- a/packages/create-react-app/src/helpers/runCommand.ts
+++ b/packages/create-react-app/src/helpers/runCommand.ts
@@ -1,0 +1,16 @@
+import { endProcess } from '@/helpers/endProcess';
+import type { ExecFileOptions } from 'child_process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const runCommand = async (command: string, args: string[] = [], options?: ExecFileOptions) => {
+  try {
+    await execFileAsync(command, args, options);
+  } catch (e) {
+    const commandStr = [command, ...args].join(' ');
+    console.error(`Failed to execute ${commandStr}`, e);
+    endProcess(true);
+  }
+};

--- a/packages/create-react-app/tests/helpers/endProcess.test.ts
+++ b/packages/create-react-app/tests/helpers/endProcess.test.ts
@@ -1,0 +1,18 @@
+import { endProcess } from '@/helpers/endProcess';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('endProcess', () => {
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation(code => {
+      throw new Error(`process.exit called with code: ${code}`);
+    });
+  });
+
+  it.each([[false], [undefined]])('should exit with code 0 when error is %s', error => {
+    expect(() => endProcess(error)).toThrow('process.exit called with code: 0');
+  });
+
+  it('should exit with code 1 when error is true', () => {
+    expect(() => endProcess(true)).toThrow('process.exit called with code: 1');
+  });
+});

--- a/packages/create-react-app/tests/helpers/runCommand.test.ts
+++ b/packages/create-react-app/tests/helpers/runCommand.test.ts
@@ -1,0 +1,58 @@
+import { runCommand } from '@/helpers/runCommand';
+import { execFile } from 'node:child_process';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+const mockConsoleError = vi.fn();
+const mockProcessExit = vi.fn();
+
+vi.stubGlobal('console', {
+  ...console,
+  error: mockConsoleError,
+});
+
+vi.stubGlobal('process', {
+  ...process,
+  exit: mockProcessExit,
+});
+
+describe('runCommand', () => {
+  it('should execute command successfully', async () => {
+    (execFile as unknown as Mock).mockImplementation((command, args, options, callback) => {
+      const cb = typeof options === 'function' ? options : callback;
+      cb(null);
+    });
+
+    await runCommand('echo', ['Hello World']);
+
+    expect(execFile).toHaveBeenCalledWith('echo', ['Hello World'], undefined, expect.any(Function));
+  });
+
+  it('should execute command with options successfully', async () => {
+    const testOptions = { cwd: '/tmp' };
+    (execFile as unknown as Mock).mockImplementation((command, args, options, callback) => {
+      const cb = typeof options === 'function' ? options : callback;
+      cb(null);
+    });
+
+    await runCommand('echo', ['Hello World'], testOptions);
+
+    expect(execFile).toHaveBeenCalledWith('echo', ['Hello World'], testOptions, expect.any(Function));
+  });
+
+  it('should handle command execution error', async () => {
+    const error = new Error('Command failed');
+    (execFile as unknown as Mock).mockImplementation((command, args, options, callback) => {
+      const cb = typeof options === 'function' ? options : callback;
+      cb(error);
+    });
+
+    await runCommand('invalid-command', ['arg']);
+
+    expect(mockConsoleError).toHaveBeenCalledWith('Failed to execute invalid-command arg', error);
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #1161

**Context:**
The previous implementation of `runCommand` used `execSync` with direct string interpolation, which could expose the codebase to shell injection vulnerabilities if untrusted values were passed. Security best practices and automated code scanning tools flagged this as a risk. Refactoring to use `execFile` eliminates shell evaluation and improves overall security.

**Proposed Changes:**
- Replaced all usages of `execSync` in `main.ts` with a new `runCommand` helper using `execFile` and argument arrays.
- Added `endProcess` helper to standardize process exit codes.
- Updated all command executions to avoid shell evaluation and use argument arrays.
- Added unit tests for `runCommand` and `endProcess` helpers.
- Updated ESLint config to enforce dependency rules.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
