### PR TITLE
Add option to skip git initialization in create-react-app

### DIFF
--- a/packages/create-react-app/README.md
+++ b/packages/create-react-app/README.md
@@ -43,6 +43,8 @@ create-react-app [options] [project-name]
 
 - `--skip-dep-install`  
   Skip installing dependencies (`npm install`).
+- `--skip-git-init`  
+  Skip initializing a git repository.
 - `-v, --version`  
   Show the version of the starter.
 

--- a/packages/create-react-app/src/main.ts
+++ b/packages/create-react-app/src/main.ts
@@ -16,7 +16,7 @@ export const main = async () => {
 
   validatePromptArgs(args);
 
-  const { projectName, skipDepInstall } = await getInteractiveArgs(args);
+  const { projectName, skipDepInstall, skipGitInit } = await getInteractiveArgs(args);
 
   const reactTemplate = '@pplancq/react-template';
 
@@ -60,17 +60,21 @@ Either try using a new directory name, or remove the files listed above.`);
   rmSync(`${repoDir}/README.md`);
   renameSync(`${repoDir}/_README.md`, `${repoDir}/README.md`);
 
-  log.info('Initialized a git repository.');
-  await runCommand('git', ['init', '--initial-branch=main'], { cwd: repoDir });
+  if (!skipGitInit) {
+    log.info('Initialized a git repository.');
+    await runCommand('git', ['init', '--initial-branch=main'], { cwd: repoDir });
+  }
 
   if (!skipDepInstall) {
     log.info('Installing packages. This might take a couple of minutes.');
     await runCommand('npm', ['install'], { cwd: repoDir });
   }
 
-  log.info('Created git commit.');
-  await runCommand('git', ['add', '.'], { cwd: repoDir });
-  await runCommand('git', ['commit', '--no-verify', '--message', 'Initial commit'], { cwd: repoDir });
+  if (!skipGitInit) {
+    log.info('Created git commit.');
+    await runCommand('git', ['add', '.'], { cwd: repoDir });
+    await runCommand('git', ['commit', '--no-verify', '--message', 'Initial commit'], { cwd: repoDir });
+  }
 
   log.success(`${pc.yellow('Success \\o/')}  Created ${pc.green(projectName)} at ${pc.green(repoDir)}`);
   note(

--- a/packages/create-react-app/src/steps/getInteractiveArgs.ts
+++ b/packages/create-react-app/src/steps/getInteractiveArgs.ts
@@ -5,16 +5,19 @@ import { confirm, text } from '@clack/prompts';
 type InteractiveArgs = {
   projectName?: string;
   skipDepInstall?: boolean;
+  skipGitInit?: boolean;
 };
 
 type InteractiveArgsResult = {
   projectName: string;
   skipDepInstall: boolean;
+  skipGitInit: boolean;
 };
 
 export const getInteractiveArgs = async ({
   projectName,
   skipDepInstall,
+  skipGitInit,
 }: InteractiveArgs): Promise<InteractiveArgsResult> => {
   return {
     projectName:
@@ -31,6 +34,13 @@ export const getInteractiveArgs = async ({
       Boolean(
         checkCancel(
           await confirm({ message: 'Do you want to skip installing dependencies (npm install)?', initialValue: false }),
+        ),
+      ),
+    skipGitInit:
+      skipGitInit ||
+      Boolean(
+        checkCancel(
+          await confirm({ message: 'Do you want to skip initializing a git repository?', initialValue: false }),
         ),
       ),
   };

--- a/packages/create-react-app/src/steps/getPromptArgs.ts
+++ b/packages/create-react-app/src/steps/getPromptArgs.ts
@@ -6,6 +6,7 @@ import packageJson from '../../package.json';
 type PromptArgsResult = {
   projectName?: string;
   skipDepInstall?: boolean;
+  skipGitInit?: boolean;
 };
 
 export const getPromptArgs = (): PromptArgsResult => {
@@ -15,6 +16,7 @@ export const getPromptArgs = (): PromptArgsResult => {
   cli
     .argument('[project-name]', 'The name of the project to create.')
     .option('--skip-dep-install', 'Skip installing dependencies (npm install).')
+    .option('--skip-git-init', 'Skip initializing a git repository.')
     .version(packageJson.version, '-v, --version')
     .name(pc.green('create-react-app'))
     .usage(`[options] ${pc.yellow('[project-name]')}`)
@@ -25,13 +27,17 @@ Examples:
   $ npm create @pplancq/react-app my-project
   $ npx @pplancq/create-react-app my-project`,
     )
-    .action((projectName?: string, options?: { skipDepInstall?: boolean }) => {
+    .action((projectName?: string, options?: { skipDepInstall?: boolean; skipGitInit?: boolean }) => {
       if (projectName) {
         result.projectName = projectName;
       }
 
       if (options?.skipDepInstall) {
         result.skipDepInstall = options.skipDepInstall;
+      }
+
+      if (options?.skipGitInit) {
+        result.skipGitInit = options.skipGitInit;
       }
     })
     .parse(process.argv);

--- a/packages/create-react-app/tests/steps/getInteractiveArgs.test.ts
+++ b/packages/create-react-app/tests/steps/getInteractiveArgs.test.ts
@@ -30,4 +30,19 @@ describe('getInteractiveArgs', () => {
 
     expect(skipDepInstall).toBeTruthy();
   });
+
+  it('returns the provided skipGitInit when specified', async () => {
+    (text as Mock).mockResolvedValueOnce('my-project');
+    const { skipGitInit } = await getInteractiveArgs({ skipGitInit: true });
+
+    expect(skipGitInit).toBeTruthy();
+  });
+
+  it('prompts for skipGitInit when not provided', async () => {
+    (text as Mock).mockResolvedValueOnce('my-project');
+    (confirm as Mock).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const { skipGitInit } = await getInteractiveArgs({});
+
+    expect(skipGitInit).toBeTruthy();
+  });
 });

--- a/packages/create-react-app/tests/steps/getPromptArgs.test.ts
+++ b/packages/create-react-app/tests/steps/getPromptArgs.test.ts
@@ -53,6 +53,22 @@ describe('processArgv', () => {
     expect(result).toStrictEqual({});
   });
 
+  it('should return skipGitInit true when --skip-git-init flag is provided', () => {
+    process.argv = ['node', 'script.js', '--skip-git-init'];
+
+    const result = getPromptArgs();
+
+    expect(result).toStrictEqual({ skipGitInit: true });
+  });
+
+  it('should not return skipGitInit when --skip-git-init flag is not provided', () => {
+    process.argv = ['node', 'script.js'];
+
+    const result = getPromptArgs();
+
+    expect(result).toStrictEqual({});
+  });
+
   it.each([{ arg: '--version' }, { arg: '-v' }])('should print version when $arg flag is provided', ({ arg }) => {
     process.argv = ['node', 'script.js', arg];
 


### PR DESCRIPTION
**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #1169

**Context:**
Currently, create-react-app always initializes a git repository when creating a new project. Some users prefer to manage version control manually or use a different workflow. This PR adds a CLI option to skip git initialization, improving flexibility for various project setups.

**Proposed Changes:**
- Added `--skip-git-init` option to the CLI and updated documentation.
- Modified project creation logic to conditionally run git initialization and initial commit based on the new option.
- Updated interactive prompts to support skipping git initialization.
- Added and updated tests to cover the new option and its behavior.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None