### PR TITLE
Verify template package.json bin.template-install before post-install

### DIFF
--- a/packages/create-react-app/src/steps/postInstallTemplate.ts
+++ b/packages/create-react-app/src/steps/postInstallTemplate.ts
@@ -1,10 +1,19 @@
 import { RunCommandError } from '@/Error/RunCommandError';
 import { runCommand } from '@/helpers/runCommand';
 import { log, spinner } from '@clack/prompts';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 export const postInstallTemplate = async (projectName: string, repoDir: string) => {
   const spinnerInstance = spinner();
   let hasError = false;
+
+  const templatePackageJson = JSON.parse(readFileSync(resolve(repoDir, 'package.json'), { encoding: 'utf-8' }));
+
+  if (templatePackageJson?.bin?.['template-install'] === undefined) {
+    log.warn('No post install template script found.');
+    return;
+  }
 
   spinnerInstance.start('Running post install template script...');
   try {

--- a/packages/create-react-app/tests/steps/postInstallTemplate.test.ts
+++ b/packages/create-react-app/tests/steps/postInstallTemplate.test.ts
@@ -2,16 +2,23 @@ import { RunCommandError } from '@/Error/RunCommandError';
 import { runCommand } from '@/helpers/runCommand';
 import { postInstallTemplate } from '@/steps/postInstallTemplate';
 import { log, spinner } from '@clack/prompts';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 
 vi.mock('@/helpers/runCommand', () => ({ runCommand: vi.fn() }));
 
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
 describe('postInstallTemplate', () => {
   const projectName = 'test-project';
   const repoDir = resolve(process.cwd(), 'test-postInstallTemplate');
+  const validPackage = JSON.stringify({ bin: { 'template-install': './bin' } });
 
   it('should run npx template-install with correct args', async () => {
+    (readFileSync as Mock).mockReturnValue(validPackage);
     (runCommand as unknown as Mock).mockResolvedValue(undefined);
 
     await postInstallTemplate(projectName, repoDir);
@@ -24,6 +31,7 @@ describe('postInstallTemplate', () => {
   });
 
   it('should log error and return when RunCommandError is thrown', async () => {
+    (readFileSync as Mock).mockReturnValue(validPackage);
     (runCommand as unknown as Mock).mockRejectedValueOnce(new RunCommandError('failed'));
 
     await postInstallTemplate(projectName, repoDir);
@@ -34,11 +42,21 @@ describe('postInstallTemplate', () => {
   });
 
   it('should rethrow non-RunCommandError errors', async () => {
+    (readFileSync as Mock).mockReturnValue(validPackage);
     (runCommand as unknown as Mock).mockRejectedValueOnce(new Error('boom'));
 
     await expect(postInstallTemplate(projectName, repoDir)).rejects.toThrow(Error);
 
     const spinnerInstance = (spinner as unknown as Mock).mock.results[0].value;
     expect(spinnerInstance.stop).toHaveBeenCalledWith('Failed to run post install template script.');
+  });
+
+  it('should warn and return when package.json has no template-install bin', async () => {
+    (readFileSync as Mock).mockReturnValue(JSON.stringify({}));
+
+    await postInstallTemplate(projectName, repoDir);
+
+    expect(log.warn).toHaveBeenCalledWith('No post install template script found.');
+    expect(runCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/create-react-app/vitest.setup.ts
+++ b/packages/create-react-app/vitest.setup.ts
@@ -10,6 +10,7 @@ vi.mock('@clack/prompts', () => ({
   outro: vi.fn(),
   log: {
     error: vi.fn(),
+    warn: vi.fn(),
   },
   spinner: vi.fn().mockImplementation(() => ({
     start: vi.fn(),


### PR DESCRIPTION
**Type of Pull Request:**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #1176

**Context:**
The CLI currently attempts to run a template post-install script unconditionally, which can fail when a template's package.json does not expose the expected bin.template-install entry. This causes confusing runtime errors for template consumers. The change adds a guard to detect the missing binary and skip execution with a clear warning.

**Proposed Changes:**
- packages/create-react-app/src/steps/postInstallTemplate.ts
  - Read and parse the template's package.json.
  - Check for templatePackageJson?.bin?.['template-install'] and, if missing, call log.warn('No post install template script found.') and return early (no runCommand).
- packages/create-react-app/tests/steps/postInstallTemplate.test.ts
  - Mock node:fs.readFileSync and add a test asserting that when package.json contains no template-install bin, a warning is logged and runCommand is not invoked.
  - Ensure existing tests mock readFileSync to provide a valid package.json where appropriate.
- packages/create-react-app/vitest.setup.ts
  - Add mock for log.warn so tests can assert warnings without noisy output.
- General: minimal, localized behavior change — skip running the post-install script when not provided and surface a helpful warning.

**Checklist:**

- [ ] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [ ] I have thought to rebase my branch
- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
This is a low-risk change that prevents a runtime failure and improves DX for template consumers and authors. No migration required. None
