### PR TITLE
Remove `stylelint-config-pretty-order` and inline order config for Stylelint v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17076,9 +17076,9 @@
       }
     },
     "node_modules/postcss-sorting": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.2.tgz",
-      "integrity": "sha512-M9dkSrmU00t/jK7rF6BZSZauA5MAaBW4i5EnJXspMwt4iqTh/L9j6fgMnbElEOfyRyfLfVbIHj/R52zHzAPe1Q==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-9.1.0.tgz",
+      "integrity": "sha512-Mn8KJ45HNNG6JBpBizXcyf6LqY/qyqetGcou/nprDnFwBFBLGj0j/sNKV2lj2KMOVOwdXu14aEzqJv8CIV6e8g==",
       "license": "MIT",
       "peerDependencies": {
         "postcss": "^8.4.20"
@@ -19226,21 +19226,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/stylelint-config-pretty-order": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-pretty-order/-/stylelint-config-pretty-order-0.7.0.tgz",
-      "integrity": "sha512-Wr9JEfOtY7yw1vo0E6mRHFsSD/05Ty2H/sP7VdiBGkRbK4usc/vf6j+bm1kZTIpnNwb95+oA3bWDwDTh97xYWg==",
-      "license": "MIT",
-      "dependencies": {
-        "stylelint-order": "^6.0.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "stylelint": "^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/stylelint-config-recommended": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-17.0.0.tgz",
@@ -19312,16 +19297,19 @@
       }
     },
     "node_modules/stylelint-order": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.4.tgz",
-      "integrity": "sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-7.0.1.tgz",
+      "integrity": "sha512-GWPei1zBVDDjxM+/BmcSCiOcHNd8rSqW6FUZtqQGlTRpD0Z5nSzspzWD8rtKif5KPdzUG68DApKEV/y/I9VbTw==",
       "license": "MIT",
       "dependencies": {
-        "postcss": "^8.4.32",
-        "postcss-sorting": "^8.0.2"
+        "postcss": "^8.5.6",
+        "postcss-sorting": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.1"
+        "stylelint": "^16.18.0 || ^17.0.0"
       }
     },
     "node_modules/stylelint-prettier": {
@@ -21616,9 +21604,9 @@
       "version": "4.0.6",
       "license": "MIT",
       "dependencies": {
-        "stylelint-config-pretty-order": "^0.7.0",
         "stylelint-config-recommended-scss": "^16.0.2",
-        "stylelint-config-standard": "^39.0.1"
+        "stylelint-config-standard": "^39.0.1",
+        "stylelint-order": "^7.0.1"
       },
       "bin": {
         "init-stylelint-config": "bin/init.js"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -39,9 +39,9 @@
     "config"
   ],
   "dependencies": {
-    "stylelint-config-pretty-order": "^0.7.0",
     "stylelint-config-recommended-scss": "^16.0.2",
-    "stylelint-config-standard": "^39.0.1"
+    "stylelint-config-standard": "^39.0.1",
+    "stylelint-order": "^7.0.1"
   },
   "peerDependencies": {
     "prettier": "^3.1.1",

--- a/packages/stylelint-config/rules/order.js
+++ b/packages/stylelint-config/rules/order.js
@@ -1,3 +1,422 @@
+function after(name) {
+  return suffix => `${name}${suffix}`;
+}
+
+function before(name) {
+  return prefix => `${prefix}${name}`;
+}
+
+function border(name) {
+  const infix = name !== undefined ? `-${name}` : '';
+
+  return ['', '-width', '-style', '-color'].map(after(infix)).map(after('border'));
+}
+
+function startEnd(name) {
+  return ['', '-start', '-end'].map(after(name));
+}
+
+function topRightBottomLeft(name) {
+  const prefix = name !== undefined ? `${name}-` : '';
+  const properties = ['top', 'right', 'bottom', 'left'].map(after(prefix));
+
+  return [name ?? [], properties].flat();
+}
+
+function xY(name) {
+  return ['-x', '-y'].map(after(name));
+}
+
+function inlineBlock(name) {
+  return ['-inline', '-block'].map(after(name));
+}
+
+function xYInlineBlock(name) {
+  return [name, ...xY(name), ...inlineBlock(name)];
+}
+
+function inlineBlockWithStartEnd(name) {
+  return inlineBlock(name).flatMap(startEnd);
+}
+
+function allSizes(name) {
+  return [...topRightBottomLeft(name), ...inlineBlockWithStartEnd(name)];
+}
+
+function minMax(name) {
+  return ['', 'min-', 'max-'].map(before(name));
+}
+
+function contentItemsSelf(name) {
+  return ['-content', '-items', '-self'].map(after(name));
+}
+
 module.exports = {
-  extends: ['stylelint-config-pretty-order'],
+  plugins: ['stylelint-order'],
+  rules: {
+    'order/properties-order': [
+      [
+        'all',
+
+        // position
+        'position',
+        'z-index',
+        'isolation',
+        topRightBottomLeft(),
+        'inset',
+        inlineBlock('inset').flatMap(startEnd),
+
+        // anchor
+        'anchor-name',
+        'position-anchor',
+        'position-try-options',
+        'position-visibility',
+        'inset-area',
+
+        // flow control
+        'float',
+        'clear',
+
+        // box
+        'display',
+        'box-sizing',
+
+        // container
+        'container',
+        'container-name',
+        'container-type',
+
+        // size
+        ['width', 'height', 'inline-size', 'block-size'].flatMap(minMax),
+        'aspect-ratio',
+
+        // margin
+        allSizes('margin'),
+
+        // padding
+        allSizes('padding'),
+
+        // border
+        border(),
+        topRightBottomLeft().flatMap(border),
+        ['inline', 'block'].flatMap(startEnd).flatMap(border),
+        'border-radius',
+        'border-top-left-radius',
+        'border-top-right-radius',
+        'border-bottom-right-radius',
+        'border-bottom-left-radius',
+        'border-start-start-radius',
+        'border-start-end-radius',
+        'border-end-end-radius',
+        'border-end-start-radius',
+        'border-image',
+        'border-image-source',
+        'border-image-slice',
+        'border-image-width',
+        'border-image-outset',
+        'border-image-repeat',
+        'border-spacing',
+
+        // grid
+        'grid',
+        'grid-area',
+        'grid-template',
+        'grid-template-areas',
+        'grid-template-columns',
+        'grid-template-rows',
+        'grid-auto-flow',
+        'grid-auto-columns',
+        'grid-auto-rows',
+        'grid-gap',
+        startEnd('grid-column'),
+        startEnd('grid-row'),
+
+        // flex
+        'flex',
+        'flex-basis',
+        'flex-direction',
+        'flex-flow',
+        'flex-grow',
+        'flex-shrink',
+        'flex-wrap',
+        'order',
+
+        // place
+        ['align', 'place', 'justify'].flatMap(contentItemsSelf),
+        'gap',
+        'column-gap',
+        'row-gap',
+        'vertical-align',
+
+        // table
+        'table-layout',
+        'caption-side',
+        'empty-cells',
+        'border-collapse',
+
+        // column
+        'columns',
+        'column-count',
+        'column-fill',
+        'column-rule',
+        'column-rule-color',
+        'column-rule-style',
+        'column-rule-width',
+        'column-span',
+        'column-width',
+        'orphans',
+        'widows',
+
+        // content visibility
+        'content-visibility',
+
+        // contain
+        'contain',
+        'contain-intrinsic-size',
+        'contain-intrinsic-width',
+        'contain-intrinsic-height',
+        'contain-intrinsic-inline-size',
+        'contain-intrinsic-block-size',
+
+        // overflow
+        xYInlineBlock('overflow'),
+        'overflow-anchor',
+        'overflow-clip-margin',
+
+        // scroll
+        'scroll-behavior',
+        allSizes('scroll-margin'),
+        allSizes('scroll-padding'),
+        'scroll-snap-align',
+        'scroll-snap-stop',
+        'scroll-snap-type',
+        xYInlineBlock('overscroll-behavior'),
+        'font',
+        'font-family',
+        'font-size',
+        'font-size-adjust',
+        'font-stretch',
+        'font-style',
+        'font-variant',
+        'font-weight',
+        'font-feature-settings',
+        'font-kerning',
+        'font-language-override',
+        'font-optical-sizing',
+        'font-palette',
+        'font-synthesis',
+        'font-variant-alternates',
+        'font-variant-caps',
+        'font-variant-east-asian',
+        'font-variant-ligatures',
+        'font-variant-numeric',
+        'font-variant-position',
+        'font-variation-settings',
+        'font-display',
+        'letter-spacing',
+        'line-height',
+
+        // @font-face
+        'src',
+        'ascent-override',
+        'descent-override',
+        'line-gap-override',
+        'unicode-range',
+
+        // text
+        'text-align',
+        'text-align-last',
+        'text-combine-upright',
+        'text-decoration',
+        'text-decoration-color',
+        'text-decoration-line',
+        'text-decoration-style',
+        'text-decoration-skip-ink',
+        'text-decoration-thickness',
+        'text-indent',
+        'text-justify',
+        'text-shadow',
+        'text-overflow',
+        'text-rendering',
+        'text-size-adjust',
+        'text-transform',
+        'text-underline-offset',
+        'text-underline-position',
+        'text-emphasis',
+        'text-emphasis-color',
+        'text-emphasis-position',
+        'text-emphasis-style',
+        'text-orientation',
+
+        // white space & word wrapping
+        'white-space',
+        'white-space-collapse',
+        'word-spacing',
+        'word-wrap',
+        'word-break',
+        'overflow-wrap',
+
+        // letter appearance
+        'initial-letter',
+        'initial-letter-align',
+        'tab-size',
+        'hyphens',
+        'hyphenate-character',
+        'hyphenate-limit-chars',
+        'quotes',
+        'line-break',
+        'ruby-align',
+        'ruby-position',
+        'writing-mode',
+
+        // visibility
+        'opacity',
+        'visibility',
+        'backface-visibility',
+
+        // color
+        'color-scheme',
+        'color',
+        'accent-color',
+        'caret-color',
+
+        // background
+        'background',
+        'background-attachment',
+        'background-blend-mode',
+        'background-clip',
+        'background-color',
+        'background-image',
+        'background-origin',
+        'background-position',
+        'background-position-x',
+        'background-position-y',
+        'background-repeat',
+        'background-size',
+        'box-shadow',
+        'mix-blend-mode',
+
+        // image
+        'image-orientation',
+        'image-rendering',
+        'image-resolution',
+        'object-fit',
+        'object-position',
+
+        // outline
+        'outline',
+        'outline-color',
+        'outline-offset',
+        'outline-style',
+        'outline-width',
+
+        // scrollbar
+        'scrollbar-color',
+        'scrollbar-gutter',
+        'scrollbar-width',
+
+        // filter
+        'filter',
+        'backdrop-filter',
+
+        // mask / clip
+        'mask',
+        'mask-clip',
+        'mask-composite',
+        'mask-image',
+        'mask-mode',
+        'mask-origin',
+        'mask-position',
+        'mask-repeat',
+        'mask-size',
+        'mask-type',
+        'clip',
+        'clip-path',
+
+        // shape
+        'shape-image-threshold',
+        'shape-margin',
+        'shape-outside',
+
+        // svg
+        'paint-order',
+
+        // transform
+        'translate',
+        'rotate',
+        'scale',
+        'transform',
+        'transform-origin',
+        'transform-style',
+        'transform-box',
+        'perspective',
+        'perspective-origin',
+
+        // animation
+        'animation',
+        'animation-delay',
+        'animation-direction',
+        'animation-duration',
+        'animation-fill-mode',
+        'animation-iteration-count',
+        'animation-name',
+        'animation-play-state',
+        'animation-range',
+        'animation-range-start',
+        'animation-range-end',
+        'animation-timeline',
+        'animation-timing-function',
+        'interpolate-size',
+
+        // transition
+        'transition',
+        'transition-delay',
+        'transition-duration',
+        'transition-property',
+        'transition-timing-function',
+
+        // view transition
+        'view-transition-name',
+
+        // timeline
+        'view-timeline',
+        'view-timeline-name',
+        'view-timeline-axis',
+        'view-timeline-inset',
+        'scroll-timeline',
+        'scroll-timeline-name',
+        'scroll-timeline-axis',
+        'timeline-scope',
+
+        // offset
+        'offset',
+        'offset-anchor',
+        'offset-distance',
+        'offset-path',
+        'offset-position',
+        'offset-rotate',
+
+        // action
+        'cursor',
+        'user-select',
+        'pointer-events',
+        'touch-action',
+        'resize',
+
+        // content
+        'content',
+        'counter-increment',
+        'counter-reset',
+        'counter-set',
+
+        // page & print
+        'page',
+        'page-break-before',
+        'page-break-inside',
+        'page-break-after',
+        'print-color-adjust',
+      ].flat(),
+      { unspecified: 'bottomAlphabetical', severity: 'warning' },
+    ],
+  },
 };


### PR DESCRIPTION
**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**
Closes #1479

**Context:**
The migration to Stylelint v11 was blocked by the unmaintained `stylelint-config-pretty-order` dependency, which is incompatible and introduces risk. This PR removes that dependency and inlines its configuration directly into the `stylelint-config` package, ensuring full compatibility with Stylelint v11 and eliminating external maintenance risk.

**Proposed Changes:**
- Remove `stylelint-config-pretty-order` from all dependencies and lockfiles.
- Add `stylelint-order` as a direct dependency.
- Inline the property order configuration previously provided by `stylelint-config-pretty-order` into `rules/order.js`.
- Refactor the Stylelint config to use the new inlined order rules.
- Update related documentation and package manifests to reflect the change.
- Ensure compatibility with Stylelint v11 and unblock the migration.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
None
