### PR TITLE
Migrate postcss-config package to ESM-only and update usage documentation

### DIFF
--- a/packages/postcss-config/README.md
+++ b/packages/postcss-config/README.md
@@ -22,4 +22,30 @@ npx init-postcss-config
 
 ### @pplancq/postcss-config
 
-This is the default configuration. To use, add `module.exports = require('@pplancq/postcss-config');` to your `.postcssrc.js`.
+This is the default configuration. To use it, see the ESM migration section below for the correct syntax.
+
+## ⚠️ Breaking Change: ESM Only from v2
+
+As of version 2.x, this package is ESM-only. CommonJS (`require`) is no longer supported.
+
+## Migration from CommonJS to ESM
+
+**Old (CommonJS) usage:**
+
+```js
+// .postcssrc.js or postcss.config.js
+module.exports = require('@pplancq/postcss-config');
+```
+
+**New (ESM) usage:**
+
+```js
+// postcss.config.mjs (or postcss.config.js when using "type": "module")
+import defaultConfig from '@pplancq/postcss-config';
+
+export default {
+  ...defaultConfig,
+};
+```
+
+If you are using a `.js` config file, ensure your environment supports ESM (e.g., Node.js >= 18, or set "type": "module" in your package.json).

--- a/packages/postcss-config/bin/init.js
+++ b/packages/postcss-config/bin/init.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-const { writeFileSync } = require('fs');
-
-console.info('Add postcss config in .postcssrc.js');
-
-writeFileSync('.postcssrc.js', "module.exports = require('@pplancq/postcss-config');\n", { encoding: 'utf-8' });

--- a/packages/postcss-config/bin/init.mjs
+++ b/packages/postcss-config/bin/init.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+
+console.info('Add postcss config in postcss.config.mjs');
+
+writeFileSync(
+  'postcss.config.mjs',
+  `import defaultConfig from '@pplancq/postcss-config';
+
+export default {
+  ...defaultConfig,
+};
+`,
+  { encoding: 'utf-8' },
+);

--- a/packages/postcss-config/index.js
+++ b/packages/postcss-config/index.js
@@ -1,8 +1,9 @@
-const postcssFlexbugsFixes = require('postcss-flexbugs-fixes');
-const postcssPresetEnv = require('postcss-preset-env');
-const postcssNormalize = require('postcss-normalize');
+import postcssFlexbugsFixes from 'postcss-flexbugs-fixes';
+import postcssPresetEnv from 'postcss-preset-env';
+import postcssNormalize from 'postcss-normalize';
 
-module.exports = {
+// eslint-disable-next-line import/no-default-export
+export default {
   ident: 'postcss',
   config: false,
   plugins: [

--- a/packages/postcss-config/package.json
+++ b/packages/postcss-config/package.json
@@ -24,9 +24,15 @@
   "bugs": {
     "url": "https://github.com/pplancq/dev-tools/issues"
   },
-  "main": "index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "bin": {
-    "init-postcss-config": "bin/init.js"
+    "init-postcss-config": "bin/init.mjs"
   },
   "keywords": [
     "postcss",


### PR DESCRIPTION
**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Other (specify): breaking change, migration

**Associated Issue:**
Closes #1477

**Context:**
The latest version of `postcss-preset-env` dropped CommonJS support, breaking compatibility with the current `postcss-config` package. This migration is required to unblock dependency updates, prevent build failures, and align with the modern JavaScript ecosystem. The change is a breaking one, requiring consumers to update their configuration files to ESM syntax.

**Proposed Changes:**
- Refactor all `postcss-config` source files to use ESM (`import`/`export default` syntax)
- Update `package.json` to set `"type": "module"` and define ESM exports
- Replace the CommonJS CLI init script with an ESM version (`init.mjs`)
- Update documentation to explain the ESM-only migration and provide migration instructions
- Remove legacy CommonJS usage and document breaking changes for consumers

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
This is a breaking change. Consumers must update their config files to use ESM import/export. See the updated README for migration instructions. No other risks or migration steps identified beyond those documented.
