### PR TITLE
Add --ignore-scripts to npm ci and run prepare for Copilot workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         run: npm run package:check
 
       - name: Install package
-        run: npm ci
+        run: npm ci --ignore-scripts
 
   commitlint:
     if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'copilot/')

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,4 +27,7 @@ jobs:
           disabled-cache: true
 
       - name: Install package
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Run prepare (init Husky)
+        run: npm run prepare

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           use-mise: true
 
       - name: Install package
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Config npm
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ junit-report.xml
 sonar-report.xml
 /packages/react-template/public/mockServiceWorker.js
 tsconfig.*.json
+/.copilot/


### PR DESCRIPTION
**Type of Pull Request:**

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (specify): Chore (CI/workflows)

**Associated Issue:**
N/A

**Context:**
SonarCloud flagged security hotspots that call out the risk of omitting `--ignore-scripts` (execution of lifecycle scripts during install). To reduce the attack surface in CI, this change ensures dependency installs do not run dependency lifecycle scripts by default while explicitly re-initializing the Husky hooks only where needed. The intent is to mitigate the Sonar S6505 hotspot while preserving required behavior for the Copilot setup.

**Proposed Changes:**
- Replace `npm ci` with `npm ci --ignore-scripts` in:
  - .github/workflows/build.yaml (Install package step)
  - .github/workflows/release.yaml (Install package step)
  - .github/workflows/copilot-setup-steps.yml (Install package step)
- Add a new step in .github/workflows/copilot-setup-steps.yml immediately after the install:
  - `Run prepare (init Husky)` which runs `npm run prepare` to initialize Husky for the Copilot workflow (this workflow needs hooks active).
- Intentionally leave the `npm install` used in the "Update package-lock.json" step unchanged to avoid altering lockfile generation behavior in releases.

**Checklist:**

- [ ] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [ ] I have thought to rebase my branch
- [ ] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**
- Risks: `--ignore-scripts` prevents lifecycle scripts (preinstall/install/postinstall/prepare) from running, which can break packages that rely on those scripts for native builds, generated artifacts, or initializers (e.g., native modules, template initializers, msw setup). This PR mitigates Husky specifically by running `npm run prepare` in the Copilot workflow; other required lifecycle behavior should be validated in CI runs. If CI shows missing steps (build/test failures), consider invoking the necessary lifecycle commands explicitly (e.g., `npm run <script>`) or scoping `--ignore-scripts` usage to jobs that do not need install-time scripts.
- Migration notes: Run the updated workflows in CI and validate all jobs (lint/test/build/release). If any job depends on install-time scripts, update that job to explicitly run the needed script(s).