### PR TITLE
fix(react-template): remove demo tests and format generated files after remove:demo

### DIFF
--- a/packages/react-template/scripts/removeDemo.cjs
+++ b/packages/react-template/scripts/removeDemo.cjs
@@ -1,14 +1,33 @@
 #!/usr/bin/env node
 const { rmSync, readFileSync, writeFileSync, mkdirSync } = require("node:fs");
 const { resolve } = require("node:path");
+const { execFileSync } = require("node:child_process");
 
 const resolveSrc = (path) => resolve(__dirname, `../src${path}`);
 
 rmSync(resolveSrc("/demo"), { recursive: true, force: true });
+rmSync(resolve(__dirname, "../tests/unit/demo"), { recursive: true, force: true });
+rmSync(resolve(__dirname, "../tests/e2e/demo.test.ts"), { force: true });
+writeFileSync(
+  resolve(__dirname, "../tests/e2e/home.test.ts"),
+  [
+    'import { expect } from "@playwright/test";',
+    'import { describe, it } from "./fixture/playwright.fixture";',
+    "",
+    'describe("Home", () => {',
+    '  it("should display the home page", async ({ page }) => {',
+    '    await page.goto("/");',
+    '    await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();',
+    "  });",
+    "});",
+    "",
+  ].join("\n"),
+  { encoding: "utf-8" },
+);
 
 rmSync(resolveSrc("/app/assets/css/mainBody.css"), { force: true });
 writeFileSync(resolveSrc("/app/assets/css/global.css"), ":root {\n  --white-color: #fff;\n}\n", { encoding: "utf-8" });
-writeFileSync(resolveSrc("/app/assets/css/index.ts"), "import './reset.css';\nimport './global.css';\n", {
+writeFileSync(resolveSrc("/app/assets/css/index.ts"), 'import "./reset.css";\nimport "./global.css";\n', {
   encoding: "utf-8",
 });
 
@@ -28,9 +47,9 @@ writeFileSync(resolveSrc("/home/serviceIdentifiers.ts"), "export const HOME_SERV
 writeFileSync(
   resolveSrc("/home/serviceHome.ts"),
   [
-    "import { ContainerModule } from 'inversify';",
+    'import { ContainerModule } from "inversify";',
     "",
-    "export const serviceHome: ContainerModule = new ContainerModule(_options => {",
+    "export const serviceHome: ContainerModule = new ContainerModule(() => {",
     "  // Register your home context services here",
     "});",
     "",
@@ -42,14 +61,12 @@ mkdirSync(resolveSrc("/home/ui/pages/Home"), { recursive: true });
 writeFileSync(
   resolveSrc("/home/ui/pages/Home/Home.tsx"),
   [
-    "export const Home = () => {",
-    "  return (",
-    "    <section>",
-    "      <h1>Home</h1>",
-    "      <p>Your demo context has been removed. Start building your first bounded context from here.</p>",
-    "    </section>",
-    "  );",
-    "};",
+    "export const Home = () => (",
+    "  <section>",
+    "    <h1>Home</h1>",
+    "    <p>Your demo context has been removed. Start building your first bounded context from here.</p>",
+    "  </section>",
+    ");",
     "",
   ].join("\n"),
   { encoding: "utf-8" },
@@ -58,15 +75,15 @@ writeFileSync(
 mkdirSync(resolveSrc("/home/ui/routing"), { recursive: true });
 writeFileSync(
   resolveSrc("/home/ui/routing/homeAppRoutes.ts"),
-  ["export const homeAppRoutes = Object.freeze({", "  home: '/',", "});", ""].join("\n"),
+  ["export const homeAppRoutes = Object.freeze({", '  home: "/",', "});", ""].join("\n"),
   { encoding: "utf-8" },
 );
 
 writeFileSync(
   resolveSrc("/home/ui/routing/homeRoutes.tsx"),
   [
-    "import { Home } from '@Home/ui/pages/Home/Home';",
-    "import type { RouteObject } from 'react-router';",
+    'import { Home } from "@Home/ui/pages/Home/Home";',
+    'import type { RouteObject } from "react-router";',
     "",
     "export const homeRoutes: RouteObject = {",
     "  children: [",
@@ -84,8 +101,8 @@ writeFileSync(
 writeFileSync(
   resolveSrc("/app/config/serviceContainer.ts"),
   [
-    "import { serviceHome } from '@Home/serviceHome';",
-    "import { Container } from 'inversify';",
+    'import { serviceHome } from "@Home/serviceHome";',
+    'import { Container } from "inversify";',
     "",
     "export const serviceContainer = new Container();",
     "",
@@ -98,12 +115,12 @@ writeFileSync(
 writeFileSync(
   resolveSrc("/app/routing/routes.tsx"),
   [
-    "import { homeRoutes } from '@Home/ui/routing/homeRoutes';",
-    "import type { RouteObject } from 'react-router';",
+    'import { homeRoutes } from "@Home/ui/routing/homeRoutes";',
+    'import type { RouteObject } from "react-router";',
     "",
     "export const routeObject: RouteObject[] = [",
     "  {",
-    "    path: '/',",
+    '    path: "/",',
     "    children: [homeRoutes],",
     "  },",
     "];",
@@ -115,12 +132,21 @@ writeFileSync(
 const tsconfigJson = JSON.parse(readFileSync(resolve(__dirname, "../tsconfig.json"), { encoding: "utf-8" }));
 delete tsconfigJson.compilerOptions.paths["@Demo/*"];
 tsconfigJson.compilerOptions.paths["@Home/*"] = ["./src/home/*"];
-writeFileSync(resolve(__dirname, "../tsconfig.json"), JSON.stringify(tsconfigJson, null, 2), { encoding: "utf-8" });
+writeFileSync(resolve(__dirname, "../tsconfig.json"), `${JSON.stringify(tsconfigJson, null, 2)}\n`, {
+  encoding: "utf-8",
+});
 
 const packagesJson = JSON.parse(readFileSync(resolve(__dirname, "../package.json"), { encoding: "utf-8" }));
 const { "remove:demo": _, ...scripts } = packagesJson.scripts;
 packagesJson.scripts = { ...scripts };
-writeFileSync(resolve(__dirname, "../package.json"), JSON.stringify(packagesJson, null, 2), { encoding: "utf-8" });
+writeFileSync(resolve(__dirname, "../package.json"), `${JSON.stringify(packagesJson, null, 2)}\n`, {
+  encoding: "utf-8",
+});
+
+execFileSync(require.resolve("prettier/bin/prettier.cjs"), ["--write", "package.json", "tsconfig.json"], {
+  cwd: resolve(__dirname, ".."),
+  stdio: "ignore",
+});
 
 rmSync(resolve(__dirname, "../scripts/removeDemo.cjs"));
 


### PR DESCRIPTION
Closes #1850

## Bug description

After running `npm run remove:demo` in a freshly initialized `@pplancq/react-template` project, the validation pipeline failed because:

1. Orphaned demo tests in `tests/unit/demo/` still imported removed `@Demo/...` modules.
2. Generated source files used single quotes and arrow-function styles that conflicted with the project's Prettier/ESLint rules.
3. `package.json` and `tsconfig.json` were rewritten without a trailing newline, causing Prettier to complain.
4. The demo e2e test in `tests/e2e/demo.test.ts` was left behind, failing against the new home page.

## Changes

- Remove `tests/unit/demo/` and `tests/e2e/demo.test.ts` during `remove:demo`.
- Add a minimal `tests/e2e/home.test.ts` so the e2e suite still has tests to run.
- Rewrite all generated `.ts`/`.tsx` files with double quotes and Prettier-compatible formatting.
- Use `() => { ... }` for the empty `ContainerModule` callback to avoid the `@typescript-eslint/no-unused-vars` error.
- Use implicit return in the generated `Home` component to satisfy `arrow-body-style`.
- Add trailing newlines to rewritten `package.json` and `tsconfig.json`, then run Prettier on them to ensure they match the project's formatting rules.

## Verification

Tested by copying the template to a temporary directory, running `node scripts/removeDemo.cjs`, and executing the full validation command from the issue:

```bash
npm run lint && npm run test -- --coverage && npm run build
```

All steps now pass.
